### PR TITLE
Enabled pip caching

### DIFF
--- a/buildspec-dev.yaml
+++ b/buildspec-dev.yaml
@@ -69,3 +69,7 @@ phases:
       - $TAG "Integration tests" "python -m unittest it/test_*.py"
       # Remove all unneeded s3 folders inside SAM_S3_BUCKET
       - $TAG "Clean up" "aws s3 rm s3://$SAM_S3_BUCKET/dev/$CLEAN_PR --recursive" > /dev/null
+
+cache:
+  paths:
+    - "/root/.cache/pip/**/*"

--- a/setup-template.yaml
+++ b/setup-template.yaml
@@ -134,7 +134,7 @@ Resources:
       Name: !Sub ${ServiceName}-dev
       ServiceRole: !GetAtt CodebuildRole.Arn
       Artifacts:
-        Type: no_artifacts
+        Type: NO_ARTIFACTS
       Environment:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL
@@ -161,7 +161,7 @@ Resources:
       BadgeEnabled: true
       ServiceRole: !GetAtt CodebuildRole.Arn
       Artifacts:
-        Type: no_artifacts
+        Type: NO_ARTIFACTS
       Environment:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL

--- a/setup-template.yaml
+++ b/setup-template.yaml
@@ -72,10 +72,26 @@ Resources:
       Name: !Sub /${ServiceName}/build/SAM_S3_BUCKET
       Type: String
       Value: !Sub ${ServiceName}-${AWS::Region}-output
+
+  # S3
   CodebuildOutputS3Bucket:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: !Sub ${ServiceName}-${AWS::Region}-output
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+  CodebuildCachingS3Bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub ${ServiceName}-${AWS::Region}-pip-cache
+      LifecycleConfiguration:
+        Rules:
+          - Id: CacheExpiry
+            Status: Enabled
+            ExpirationInDays: 03
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true
@@ -129,6 +145,9 @@ Resources:
         Location: !Sub https://github.com/${GitHubOwner}/${GitHubRepo}.git
         Type: GITHUB
         BuildSpec: buildspec-dev.yaml
+      Cache:
+        Type: S3
+        Location: !Ref CodebuildCachingS3Bucket
       Triggers:
         Webhook: true
         FilterGroups:


### PR DESCRIPTION
Pip dependencies for dev builds get cached in an S3 bucket.
All PR builds share the same dependencies.
Cache is invalidated every 3 days.